### PR TITLE
Memory translation

### DIFF
--- a/.overrides/translation-memory.rst
+++ b/.overrides/translation-memory.rst
@@ -26,11 +26,14 @@ Si quieres ver cómo se ha utilizado un término anteriormente, puedes utilizar 
    ├────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
 
 
-:loop:
-   Bucle. ``tutorial/controlflow.po``
+Éstos son las palabras que hemos coordinado hasta el momento:
 
-:handle exception:
-   Gestionar excepción. ``tutorial/inputoutput.po``
 
-:docstring:
-   docstring. ``library/idle.po``
+   loop
+      Bucle. ``tutorial/controlflow.po``
+
+   handle exception
+      Gestionar excepción. ``tutorial/inputoutput.po``
+
+   docstring
+      docstring. ``library/idle.po``

--- a/.overrides/translation-memory.rst
+++ b/.overrides/translation-memory.rst
@@ -1,0 +1,36 @@
+=======================
+ Memoria de traducción
+=======================
+
+
+Esta página contiene la Memoria de Traducción, con todos los términos que hemos ido teniendo dudas,
+y coordinamos cuál era la mejor traducción dado el contexto.
+
+Si quieres ver cómo se ha utilizado un término anteriormente, puedes utilizar la herramienta
+``find_in_po.py`` que muestra dónde se usó ese término: original y traducción lado a lado:
+
+.. code-block:: bash
+
+   $ python scripts/find_in_po.py docstring
+   ╒════════════════════════════════════════════════════════════════════════════════════════════════╤═══════════════════════════════════════════════════════════════════════════════════════════════╕
+   │ The first statement of the function body can optionally be a string literal; this string       │ La primera sentencia del cuerpo de la función puede ser opcionalmente una cadena de texto     │
+   │ literal is the function's documentation string, or :dfn:`docstring`. (More about docstrings    │ literal; esta es la cadena de texto de documentación de la función, o :dfn:`docstring`.       │
+   │ can be found in the section :ref:`tut-docstrings`.) There are tools which use docstrings to    │ (Puedes encontrar más acerca de docstrings en la sección :ref:`tut-docstrings`.). Existen     │
+   │ automatically produce online or printed documentation, or to let the user interactively browse │ herramientas que usan las ``docstrings`` para producir documentación imprimible o disponible  │
+   │ through code; it's good practice to include docstrings in code that you write, so make a habit │ en línea, o para dejar que los usuarios busquen interactivamente a través del código; es una  │
+   │ of it.                                                                                         │ buena práctica incluir ``docstrings`` en el código que escribes, y hacerlo un buen hábito.    │
+   ├────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
+   │ Here is an example of a multi-line docstring::                                                 │ Este es un ejemplo de un ``docstring`` multi-línea::                                          │
+   ├────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
+   │ Use docstrings.                                                                                │ Usar ``docstrings``.                                                                          │
+   ├────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────┤
+
+
+:loop:
+   Bucle. ``tutorial/controlflow.po``
+
+:handle exception:
+   Gestionar excepción. ``tutorial/inputoutput.po``
+
+:docstring:
+   docstring. ``library/idle.po``

--- a/.overrides/translation-memory.rst
+++ b/.overrides/translation-memory.rst
@@ -9,7 +9,7 @@ y coordinamos cuál era la mejor traducción dado el contexto.
 Si quieres ver cómo se ha utilizado un término anteriormente, puedes utilizar la herramienta
 ``find_in_po.py`` que muestra dónde se usó ese término: original y traducción lado a lado:
 
-.. code-block:: bash
+.. code-block:: text
 
    $ python scripts/find_in_po.py docstring
    ╒════════════════════════════════════════════════════════════════════════════════════════════════╤═══════════════════════════════════════════════════════════════════════════════════════════════╕

--- a/scripts/find_in_po.py
+++ b/scripts/find_in_po.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import argparse
+from glob import glob
+import os
+from textwrap import fill
+
+import regex
+import polib
+from tabulate import tabulate
+
+
+def find_in_po(pattern):
+    table = []
+    try:
+        _, columns = os.popen("stty size", "r").read().split()
+        available_width = int(columns) // 2 - 3
+    except:
+        available_width = 80 // 2 - 3
+
+    for file in glob("**/*.po"):
+        pofile = polib.pofile(file)
+        for entry in pofile:
+            if entry.msgstr and regex.search(pattern, entry.msgid):
+                table.append(
+                    [
+                        fill(entry.msgid, width=available_width),
+                        fill(entry.msgstr, width=available_width),
+                    ]
+                )
+    print(tabulate(table, tablefmt="fancy_grid"))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Find translated words.")
+    parser.add_argument("pattern")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    find_in_po(args.pattern)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Example of memory translation to start with.

https://python-docs-es--63.org.readthedocs.build/es/63/translation-memory.html