### PR TITLE
Update README.rst

### DIFF
--- a/.overrides/CONTRIBUTING.rst
+++ b/.overrides/CONTRIBUTING.rst
@@ -115,5 +115,5 @@ Y luego accediendo a http://localhost:8000/
 .. _poedit: https://poedit.net/
 
 .. _nuestro canal de Telegram: https://t.me/python_docs_es
-.. _Memoria de traducción: https://python-docs-es.readthedocs.io/es/3.7/translation-memory.html
+.. _Memoria de traducción: https://python-docs-es.readthedocs.io/page/translation-memory.html
 .. _lista de issues en GitHub: https://github.com/PyCampES/python-docs-es/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Spanish Translation of the Python Documentation
 How to Contribute
 -----------------
 
-We have a guide that will help you to contribute at: https://python-docs-es.readthedocs.io/es/3.7/CONTRIBUTING.html.
+We have a guide that will help you to contribute at: https://python-docs-es.readthedocs.io/page/CONTRIBUTING.html.
 Please, check the details there.
 
 

--- a/scripts/create_issue.py
+++ b/scripts/create_issue.py
@@ -22,6 +22,6 @@ issue = repo.create_issue(
 
 Please, comment here if you want this file to be assigned to you and an member will assign it to you as soon as possible, so you can start working on it.
 
-Remember to follow the steps in our [Contributing Guide](https://python-docs-es.readthedocs.io/es/3.7/CONTRIBUTING.html)''',
+Remember to follow the steps in our [Contributing Guide](https://python-docs-es.readthedocs.io/page/CONTRIBUTING.html)''',
 )
 print(f'Issue created at {issue.html_url}')


### PR DESCRIPTION
The `/page` URL always go to the default version, which is 3.8 now in RTD