### PR TITLE
Traducido Código de Conducta de la PSF

### DIFF
--- a/.overrides/coc.rst
+++ b/.overrides/coc.rst
@@ -32,8 +32,8 @@ Los comportamientos que refuerzan estos valores contribuyen a un ambiente positi
   de los demás, teniendo en cuenta que muchas veces la labor se completó simplemente por el bien de
   la comunidad.
 * **Ser respetuoso de los diferentes puntos de vista y experiencias.** Somos personas receptivas a
-  los comentarios constructivos y las críticas, ya que las experiencias y habilidades de otros
-  miembros contribuyen a la totalidad de nuestros esfuerzos.
+  los comentarios constructivos y las críticas, ya que las experiencias y habilidades de otras
+  personas afiliadas contribuyen a la totalidad de nuestros esfuerzos.
 * **Mostrando empatía hacia otros miembros de la comunidad.** Estamos atentos en nuestras
   comunicaciones, ya sea en persona o en línea, y tenemos tacto cuando nos acercamos a diferentes
   puntos de vista.
@@ -64,7 +64,7 @@ Los ejemplos de comportamiento inaceptable de las personas participantes incluye
 * Acoso de cualquier participante en cualquier forma
 * Intimidación deliberada, acoso o seguimiento
 * Iniciar sesión o tomar capturas de pantalla de actividades en línea con fines de acoso
-* Publicar información privada de otros, como una dirección física o electrónica, sin permiso
+* Publicar información privada de otras personas, como una dirección física o electrónica, sin permiso
   explícito
 * Amenazas violentas o lenguaje dirigido contra otra persona
 * La incitación a la violencia o el acoso hacia cualquier persona, incluso alentar a una persona a
@@ -95,7 +95,7 @@ Política de armas
 No se permiten armas en los eventos de la *Python Software Foundation*.
 Las armas incluyen, entre otras, explosivos (incluidos fuegos artificiales), pistolas y cuchillos
 grandes, como los que se usan para cazar o exhibir, así como cualquier otro artículo que se use con
-el propósito de causar lesiones o daños a otros.
+el propósito de causar lesiones o daños a otras personas.
 A cualquiera que se vea en posesión de uno de estos artículos se le pedirá que se vaya de
 inmediato, y solo se le permitirá regresar sin el arma.
 

--- a/.overrides/coc.rst
+++ b/.overrides/coc.rst
@@ -10,7 +10,7 @@ Código de Conducta
    Complementariamente, recomendamos considerar el código de conducta
    de otras asociaciones, como `Python Argentina`_ y `Python España`_
 
-La comunidad de Python está compuesta por miembros de todo el mundo con un conjunto diverso de
+La comunidad de Python está compuesta por personas de todo el mundo con un conjunto diverso de
 habilidades, personalidades y experiencias.
 Es a través de estas diferencias que nuestra comunidad experimenta grandes éxitos y crecimiento
 continuo.
@@ -121,14 +121,14 @@ Software Foundation* y `eventos organizados por proyectos bajo el patrocinio fis
 
 * personal
 * Miembros de la junta de la *Python Software Foundation*
-* presentadores
+* presentadores y presentadoras
 * panelistas
 * líderes de tutoriales o talleres
-* presentadores de póster
+* presentadores y presentadoras de póster
 * personas invitadas a reuniones o cumbres
-* expositores
-* organizadores
-* voluntarios
+* expositores y expositoras
+* organizadores y organizadoras
+* voluntarios y voluntarias
 * todas las personas asistentes
 
 El Código de conducta se aplica en los espacios de eventos oficiales del lugar, que incluyen:
@@ -179,16 +179,16 @@ Este Código de conducta se aplica a los siguientes espacios en línea:
 Este Código de conducta se aplica a las siguientes personas en los espacios en línea oficiales
 de la *Python Software Foundation*:
 
-* administradores del espacio en línea
-* mantenedores
-* revisores
+* administradores y administradoras del espacio en línea
+* mantenedores y mantenedoras
+* revisores y revisoras
 * contribuyentes
 * todas las personas afiliadas a la comunidad
 
 Se requiere que cada espacio en línea mencionado anteriormente proporcione la siguiente información
 al grupo de trabajo del Código de Conducta de la *Python Software Foundation*:
 
-* información de contacto para cualquier administrador/moderador
+* información de contacto para cualquier administradora(or)/moderadora(or)
 
 Se recomienda que cada espacio en línea mencionado anteriormente proporcione la siguiente
 información a las personas afiliadas de la comunidad:
@@ -198,8 +198,7 @@ información a las personas afiliadas de la comunidad:
 
 El grupo de trabajo del Código de conducta de la *Python Software Foundation* recibirá y evaluará
 los informes de incidentes de las comunidades en línea mencionadas anteriormente.
-El grupo de trabajo del Código de conducta de la *Python Software Foundation* trabajará con los
-administradores/moderadores de la comunidad en línea para sugerir acciones a tomar en respuesta a
+El grupo de trabajo del Código de conducta de la *Python Software Foundation* trabajará con las personas responsables de la administración/moderación de la comunidad en línea para sugerir acciones a tomar en respuesta a
 un informe.
 En los casos en que las personas administradoras/moderadoras no estén de acuerdo con la resolución
 sugerida para un informe, el grupo de trabajo del Código de Conducta de la

--- a/.overrides/coc.rst
+++ b/.overrides/coc.rst
@@ -34,11 +34,11 @@ Los comportamientos que refuerzan estos valores contribuyen a un ambiente positi
 * **Ser respetuoso de los diferentes puntos de vista y experiencias.** Somos personas receptivas a
   los comentarios constructivos y las críticas, ya que las experiencias y habilidades de otras
   personas afiliadas contribuyen a la totalidad de nuestros esfuerzos.
-* **Mostrando empatía hacia otros miembros de la comunidad.** Estamos atentos en nuestras
+* **Mostrando empatía hacia otras personas afiliads de la comunidad.** Estamos atentos en nuestras
   comunicaciones, ya sea en persona o en línea, y tenemos tacto cuando nos acercamos a diferentes
   puntos de vista.
-* **Ser considerado.** Las personas afiliadas a la comunidad son consideradas con sus pares, otros
-  usuarios de Python.
+* **Ser considerado.** Las personas afiliadas a la comunidad son consideradas con sus pares, otras personas
+  usuarias de Python.
 * **Ser respetuoso.** Somos personas respetuosas con los demás, sus posiciones, sus habilidades,
   sus compromisos y sus esfuerzos.
 * **Aceptando con gracia las críticas constructivas.** Cuando no estamos de acuerdo, somos corteses
@@ -73,14 +73,14 @@ Los ejemplos de comportamiento inaceptable de las personas participantes incluye
 * Lenguaje e imágenes sexuales en comunidades en línea o en cualquier lugar de conferencias,
   incluidas charlas
 * Insultos, humillaciones o chistes que se basan en estereotipos, que son exclusivos o que hacen
-  que otros ridiculicen
+  que otras personas ridiculicen
 * Maldecir excesivamente
 * Atención o avances sexuales no deseados
 * Contacto físico no deseado, incluido el contacto físico simulado (por ejemplo, Descripciones
   textuales como "abrazo" o "caricias en la espalda") sin consentimiento o después de una solicitud
   para detener
 * Patrón de contacto social inapropiado, como solicitar/asumir niveles inapropiados de intimidad
-  con otros
+  con otras ersonas
 * Interrupción sostenida de las discusiones de la comunidad en línea, presentaciones en persona u
   otros eventos en persona.
 * Comunicación continua uno a uno después de las solicitudes de cesar

--- a/.overrides/coc.rst
+++ b/.overrides/coc.rst
@@ -1,0 +1,273 @@
+:orphan:
+
+Código de Conducta
+===================
+
+.. note::
+   El siguiente contenido es la traducción del Código de Conducta
+   establecido por la *Python Software Foundation* (PSF), y puedes
+   acceder al oficial en inglés, `en su sitio`_.
+   Complementariamente, recomendamos considerar el código de conducta
+   de otras asociaciones, como `Python Argentina`_ y `Python España`_
+
+La comunidad de Python está compuesta por miembros de todo el mundo con un conjunto diverso de
+habilidades, personalidades y experiencias.
+Es a través de estas diferencias que nuestra comunidad experimenta grandes éxitos y crecimiento
+continuo.
+Cuando trabajas con miembros de la comunidad, este Código de conducta te ayudará a dirigir tus
+interacciones y a mantener a Python como una comunidad positiva, próspera y en crecimiento.
+
+Nuestra comunidad
+-----------------
+
+Las personas afiliadas a la comunidad Python son **inclusivas, consideradas y respetuosas**.
+Los comportamientos que refuerzan estos valores contribuyen a un ambiente positivo e incluyen:
+
+* **Ser inclusivo (being open).** Las personas afiliadas de la comunidad están abiertas a la
+  colaboración, ya sea en PEPs, parches, problemas y otros.
+* **Centrarse en lo que es mejor para la comunidad.** Somos personas respetuosas de los procesos
+  establecidos en la comunidad y trabajamos dentro de ellas.
+* **Reconociendo tiempo y esfuerzo.** Somos personas respetuosas de los esfuerzos de las personas
+  voluntarias que impregnan la comunidad de Python. Somos personas atentas al abordar los esfuerzos
+  de los demás, teniendo en cuenta que muchas veces la labor se completó simplemente por el bien de
+  la comunidad.
+* **Ser respetuoso de los diferentes puntos de vista y experiencias.** Somos personas receptivas a
+  los comentarios constructivos y las críticas, ya que las experiencias y habilidades de otros
+  miembros contribuyen a la totalidad de nuestros esfuerzos.
+* **Mostrando empatía hacia otros miembros de la comunidad.** Estamos atentos en nuestras
+  comunicaciones, ya sea en persona o en línea, y tenemos tacto cuando nos acercamos a diferentes
+  puntos de vista.
+* **Ser considerado.** Las personas afiliadas a la comunidad son consideradas con sus pares, otros
+  usuarios de Python.
+* **Ser respetuoso.** Somos personas respetuosas con los demás, sus posiciones, sus habilidades,
+  sus compromisos y sus esfuerzos.
+* **Aceptando con gracia las críticas constructivas.** Cuando no estamos de acuerdo, somos corteses
+  al plantear nuestros problemas.
+* **Uso de un lenguaje acogedor e inclusivo.** Estamos aceptando a todas las personas que deseen
+  participar en nuestras actividades, fomentando un entorno en el que cualquiera pueda participar y
+  todas las personas puedan marcar la diferencia.
+
+Nuestros estándares
+-------------------
+
+Cada miembro de nuestra comunidad tiene derecho a que se respete su identidad.
+La comunidad de Python se dedica a proporcionar una experiencia positiva para todas las personas,
+independientemente de su edad, identidad y expresión de género, orientación sexual, discapacidad,
+apariencia física, tamaño corporal, origen étnico, nacionalidad, raza o religión (o falta de ella),
+educación o estatus socioeconómico.
+
+Comportamiento inapropiado
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Los ejemplos de comportamiento inaceptable de las personas participantes incluyen:
+
+* Acoso de cualquier participante en cualquier forma
+* Intimidación deliberada, acoso o seguimiento
+* Iniciar sesión o tomar capturas de pantalla de actividades en línea con fines de acoso
+* Publicar información privada de otros, como una dirección física o electrónica, sin permiso
+  explícito
+* Amenazas violentas o lenguaje dirigido contra otra persona
+* La incitación a la violencia o el acoso hacia cualquier persona, incluso alentar a una persona a
+  suicidarse o a autolesionarse
+* Crear cuentas en línea adicionales para hostigar a otra persona o evitar una prohibición
+* Lenguaje e imágenes sexuales en comunidades en línea o en cualquier lugar de conferencias,
+  incluidas charlas
+* Insultos, humillaciones o chistes que se basan en estereotipos, que son exclusivos o que hacen
+  que otros ridiculicen
+* Maldecir excesivamente
+* Atención o avances sexuales no deseados
+* Contacto físico no deseado, incluido el contacto físico simulado (por ejemplo, Descripciones
+  textuales como "abrazo" o "caricias en la espalda") sin consentimiento o después de una solicitud
+  para detener
+* Patrón de contacto social inapropiado, como solicitar/asumir niveles inapropiados de intimidad
+  con otros
+* Interrupción sostenida de las discusiones de la comunidad en línea, presentaciones en persona u
+  otros eventos en persona.
+* Comunicación continua uno a uno después de las solicitudes de cesar
+* Otra conducta inapropiada para un público profesional, incluidas personas de diferentes orígenes.
+
+Se espera que las personas afiliadas de la comunidad que soliciten detener cualquier comportamiento
+inapropiado cumplan de inmediato.
+
+Política de armas
+~~~~~~~~~~~~~~~~~
+
+No se permiten armas en los eventos de la *Python Software Foundation*.
+Las armas incluyen, entre otras, explosivos (incluidos fuegos artificiales), pistolas y cuchillos
+grandes, como los que se usan para cazar o exhibir, así como cualquier otro artículo que se use con
+el propósito de causar lesiones o daños a otros.
+A cualquiera que se vea en posesión de uno de estos artículos se le pedirá que se vaya de
+inmediato, y solo se le permitirá regresar sin el arma.
+
+Consecuencias
+~~~~~~~~~~~~~
+
+Si un participante se involucra en un comportamiento que viola este código de conducta, el equipo
+del Código de conducta de la comunidad de Python puede tomar cualquier acción que considere
+apropiada, incluida la advertencia al infractor o la expulsión de la comunidad y los eventos de la
+comunidad sin reembolso de los boletos del evento. La lista completa de consecuencias por
+comportamiento inapropiado se encuentra en los `Procedimientos de cumplimiento`_.
+
+Gracias por ayudarnos a hacer de esta una comunidad acogedora y amigable para todas las personas.
+
+Alcance
+-------
+
+Eventos PSF
+~~~~~~~~~~~
+
+Este Código de Conducta se aplica a las siguientes personas en eventos organizados por la *Python
+Software Foundation* y `eventos organizados por proyectos bajo el patrocinio fiscal del PSF`_:
+
+* personal
+* Miembros de la junta de la *Python Software Foundation*
+* presentadores
+* panelistas
+* líderes de tutoriales o talleres
+* presentadores de póster
+* personas invitadas a reuniones o cumbres
+* expositores
+* organizadores
+* voluntarios
+* todas las personas asistentes
+
+El Código de conducta se aplica en los espacios de eventos oficiales del lugar, que incluyen:
+
+* sala de exposiciones o área de presentación de vendedores
+* salas de paneles y presentaciones
+* hackathon o salas de sprint
+* salas de tutoría o taller
+* salas de sesiones de póster
+* cumbre o salas de reuniones
+* áreas de personal
+* suites de conferencias
+* áreas de comida
+* suites de fiesta
+* pasillos, corredores, ascensores y escaleras que conectan cualquiera de los espacios anteriores.
+
+El Código de conducta se aplica a las interacciones con cuentas de eventos oficiales en espacios
+de redes sociales y aplicaciones telefónicas, que incluyen:
+
+* comentarios hechos en aplicaciones oficiales de teléfono de conferencia
+* comentarios realizados sobre servicios de alojamiento de video de eventos
+* comentarios hechos en el hashtag oficial del evento o hashtags del panel
+
+Las personas organizadoras del evento aplicarán este código durante todo el evento.
+Cada evento debe proporcionar un comité del Código de Conducta que reciba, evalúe y actúe sobre los
+informes de incidentes.
+Cada evento debe proporcionar información de contacto del comité a las personas asistentes.
+El comité del Código de Conducta del evento puede (pero no está obligado a hacerlo) pedir consejo
+al grupo de trabajo del Código de Conducta de la *Python Software Foundation*.
+Puede comunicarse con el grupo de trabajo del Código de Conducta de la *Python Software Foundation*
+enviando un correo electrónico a `conduct-wg@python.org`.
+
+
+Espacios en línea PSF
+~~~~~~~~~~~~~~~~~~~~~
+
+Este Código de conducta se aplica a los siguientes espacios en línea:
+
+* listas de correo python-ideas, core-mentorship, python-dev, docs
+* Todas las demás listas de correo alojadas en python.org
+* Servidor de chat *Zulip* de la *Python Software Foundation*
+* Servidor *Discourse* alojado en discuss.python.org
+* Repositorios de código, rastreadores de problemas y solicitudes de extracción realizadas contra
+  cualquier organización GitHub controlada por la *Python Software Foundation*
+* El servidor mercurial de python.org ubicado en hg.python.org
+* Cualquier otro espacio en línea administrado por la *Python Software Foundation*
+
+Este Código de conducta se aplica a las siguientes personas en los espacios en línea oficiales
+de la *Python Software Foundation*:
+
+* administradores del espacio en línea
+* mantenedores
+* revisores
+* contribuyentes
+* todas las personas afiliadas a la comunidad
+
+Se requiere que cada espacio en línea mencionado anteriormente proporcione la siguiente información
+al grupo de trabajo del Código de Conducta de la *Python Software Foundation*:
+
+* información de contacto para cualquier administrador/moderador
+
+Se recomienda que cada espacio en línea mencionado anteriormente proporcione la siguiente
+información a las personas afiliadas de la comunidad:
+
+* un mensaje de bienvenida con un enlace a este Código de conducta y la información de contacto
+  para realizar un informe de incidente `conduct-wg@python.org`.
+
+El grupo de trabajo del Código de conducta de la *Python Software Foundation* recibirá y evaluará
+los informes de incidentes de las comunidades en línea mencionadas anteriormente.
+El grupo de trabajo del Código de conducta de la *Python Software Foundation* trabajará con los
+administradores/moderadores de la comunidad en línea para sugerir acciones a tomar en respuesta a
+un informe.
+En los casos en que las personas administradoras/moderadoras no estén de acuerdo con la resolución
+sugerida para un informe, el grupo de trabajo del Código de Conducta de la
+*Python Software Foundation* puede optar por notificar a la junta de la
+*Python Software Foundation*.
+
+**Información de contacto**
+
+Si cree que alguien está violando el código de conducta o tiene alguna otra inquietud, comuníquese
+con un miembro del grupo de trabajo del Código de conducta de la *Python Software Foundation* de
+inmediato.
+Se les puede contactar enviando un correo electrónico a `conduct-wg@python.org`.
+
+Procedimiento para manejar incidentes
+-------------------------------------
+
+.. TODO: No sé si deberiamos traducir el contenido de estos dos enlaces.
+
+`Community Member Procedure For Reporting Code of Conduct Incidents`_
+
+`Python Software Foundation Code of Conduct Working Group Enforcement Procedures`_
+
+Licencia
+--------
+
+Este Código de Conducta está licenciado bajo la Licencia *Creative Commons Attribution-Sharealike
+3.0 Unported*.
+
+*Creative Commons License*
+
+Atribuciones
+------------
+
+Este Código de Conducta se bifucó (fork) a partir de las pólizas de ejemplo del
+`Geek Feminism wiki, creado por Ada Initiative y otros voluntarios`_, que está bajo una licencia
+`Creative Commons Zero`_.
+
+*Sage Sharp* de `Otter Tech`_ creó un nuevo lenguage y modificaciones adicionales.
+
+El lenguaje se incorporó a partir de los siguientes códigos de conducta:
+
+* `Affect Conf Code of Conduct`_, licensed under a `Creative Commons Attribution-ShareAlike 3.0 Unported License`_.
+* `Citizen Code of Conduct`_, licensed under a `Creative Commons Attribution-ShareAlike 3.0 Unported License`_.
+* `Contributor Covenant version 1.4`_, licensed `Creative Commons Attribution 4.0 License`_.
+* `Django Project Code of Conduct`_, licensed under a `Creative Commons Attribution 3.0 Unported License`_.
+* `LGBTQ in Tech Slack Code of Conduct`_, licensed under a `Creative Commons Zero License`_.
+* `PyCon 2018 Code of Conduct`_, licensed under a `Creative Commons Attribution 3.0 Unported License`_.
+* `Rust Code of Conduct`_
+
+
+.. _`en su sitio`: https://www.python.org/psf/conduct/
+.. _`Geek Feminism wiki, creado por Ada Initiative y otros voluntarios`: http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy
+.. _`Creative Commons Zero`: https://creativecommons.org/publicdomain/zero/1.0/
+.. _`Otter Tech`: https://otter.technology/code-of-conduct-training/
+.. _`Affect Conf Code of Conduct`: https://affectconf.com/coc/
+.. _`Citizen Code of Conduct`: http://citizencodeofconduct.org/
+.. _`PyCon 2018 Code of Conduct`: https://us.pycon.org/2018/about/code-of-conduct/
+.. _`Django Project Code of Conduct`: https://www.djangoproject.com/conduct/
+.. _`LGBTQ in Tech Slack Code of Conduct`: https://lgbtq.technology/coc.html
+.. _`Contributor Covenant version 1.4`: https://www.contributor-covenant.org/version/1/4/code-of-conduct
+.. _`Creative Commons Zero License`: https://creativecommons.org/publicdomain/zero/1.0/
+.. _`Creative Commons Attribution 4.0 License`: https://github.com/ContributorCovenant/contributor_covenant/blob/master/LICENSE.md
+.. _`Creative Commons Attribution 3.0 Unported License`: http://creativecommons.org/licenses/by/3.0/
+.. _`Creative Commons Attribution-ShareAlike 3.0 Unported License`: http://creativecommons.org/licenses/by-sa/3.0/
+.. _`Rust Code of Conduct`: https://www.rust-lang.org/en-US/conduct.html
+.. _`Python Argentina`: https://ac.python.org.ar/
+.. _`Python España`: https://www.es.python.org/pages/codigo-de-conducta.html
+.. _`eventos organizados por proyectos bajo el patrocinio fiscal del PSF`: https://www.python.org/psf/fiscal-sponsorees/
+.. _`Community Member Procedure For Reporting Code of Conduct Incidents`: https://www.python.org/psf/conduct/reporting
+.. _`Python Software Foundation Code of Conduct Working Group Enforcement Procedures`: https://www.python.org/psf/conduct/enforcement
+.. _`Procedimientos de cumplimiento`: https://www.python.org/psf/conduct/enforcement


### PR DESCRIPTION
Hola!

He traducido el código de conducta de la PSF y me gustaría mucho que pudieramos estar todos de acuerdo con su adopción antes de hacerlo.

Si alguien tiene una mejor propuesta, por favor, agregarlo a esta discusión.
La interpretación del CoC en inglés me parece importantísima, con lo que espero que si hay alguna frase que no les parece, nos lo hagan saber.

Como es una traducción literal, he incluído hasta las últimas secciones donde se explica de donde nació y las diferentes Licencias, no sé si es necesario, pero estoy abierto a sus comentarios.

Hay mucha más información que no he traducido, que son links externos, y referencias a email de contacto, no estoy muy seguro de como continuar en esos aspectos:
* Traducimos también los links externos y los dejamos en otros archivos? o los dejamos como referencias a los sitios en inglés?
* Podremos conseguir un email para preguntas, y denuncias relacionadas? No sé si escribo un email en español a la dirección establecida me responderán...

Feliz de leer cualquier otro comentario